### PR TITLE
Fix NameError in delete_paste.

### DIFF
--- a/pastebin.py
+++ b/pastebin.py
@@ -342,7 +342,7 @@ class PastebinAPI(object):
 
 
         # lets try to read the URL that we've just built.
-        request = urllib.urlopen(self._api_url, urllib.urlencode(argv))
+        request_string = urllib.urlopen(self._api_url, urllib.urlencode(argv))
         response = request_string.read()
 
         return response


### PR DESCRIPTION
This fixes problem:
`NameError: global name 'request_string' is not defined`

when you call:

``` python
PastebinAPI().delete_paste(api_dev_key, api_user_key, api_paste_key)
```
