### PR TITLE
Feature/pep8 fixes

### DIFF
--- a/pastebin.py
+++ b/pastebin.py
@@ -815,8 +815,3 @@ pastes_by_user = PastebinAPI.pastes_by_user
 generate_user_key = PastebinAPI.generate_user_key
 legacy_paste = PastebinAPI.legacy_paste
 paste = PastebinAPI.paste
-
-######################################################
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
I've made some cleanup of the code basing the analysis in [pep8](http://legacy.python.org/dev/peps/pep-0008/) (the standard code style for python). And checking it with [flake8](https://pypi.python.org/pypi/flake8) (a tool that checks for pep8 violations among other things).

The current state of the `master` branch is:

```
(venv:pruebas) (git:master ✔) ➜ flake8 pastebin.py
pastebin.py:29:73: W291 trailing whitespace
pastebin.py:30:69: W291 trailing whitespace
pastebin.py:33:1: F401 'sys' imported but unused
pastebin.py:36:1: E302 expected 2 blank lines, found 1
pastebin.py:39:78: W291 trailing whitespace
pastebin.py:42:1: E302 expected 2 blank lines, found 1
pastebin.py:44:1: W293 blank line contains whitespace
pastebin.py:46:1: W293 blank line contains whitespace
pastebin.py:47:79: W291 trailing whitespace
pastebin.py:50:73: W291 trailing whitespace
pastebin.py:52:1: W293 blank line contains whitespace
pastebin.py:53:76: W291 trailing whitespace
pastebin.py:55:1: W293 blank line contains whitespace
pastebin.py:56:80: E501 line too long (80 > 79 characters)
pastebin.py:58:1: W293 blank line contains whitespace
pastebin.py:60:1: W293 blank line contains whitespace
pastebin.py:61:78: W291 trailing whitespace
pastebin.py:63:1: W293 blank line contains whitespace
pastebin.py:79:20: E225 missing whitespace around operator
pastebin.py:82:13: E225 missing whitespace around operator
pastebin.py:85:19: E225 missing whitespace around operator
pastebin.py:87:80: E501 line too long (80 > 79 characters)
pastebin.py:302:5: E303 too many blank lines (2)
pastebin.py:303:60: W291 trailing whitespace
pastebin.py:304:1: W293 blank line contains whitespace
pastebin.py:305:1: W293 blank line contains whitespace
pastebin.py:309:80: E501 line too long (84 > 79 characters)
pastebin.py:310:80: E501 line too long (83 > 79 characters)
pastebin.py:313:26: W291 trailing whitespace
pastebin.py:314:1: W293 blank line contains whitespace
pastebin.py:317:80: E501 line too long (98 > 79 characters)
pastebin.py:318:1: W293 blank line contains whitespace
pastebin.py:320:80: E501 line too long (91 > 79 characters)
pastebin.py:321:1: W293 blank line contains whitespace
pastebin.py:323:80: E501 line too long (125 > 79 characters)
pastebin.py:330:30: E203 whitespace before ':'
pastebin.py:330:49: E202 whitespace before '}'
pastebin.py:339:1: W293 blank line contains whitespace
pastebin.py:345:9: E303 too many blank lines (2)
pastebin.py:345:9: F841 local variable 'request' is assigned to but never used
pastebin.py:346:20: F821 undefined name 'request_string'
pastebin.py:351:5: E303 too many blank lines (2)
pastebin.py:353:1: W293 blank line contains whitespace
pastebin.py:354:1: W293 blank line contains whitespace
pastebin.py:372:1: W293 blank line contains whitespace
pastebin.py:373:1: W293 blank line contains whitespace
pastebin.py:375:80: E501 line too long (98 > 79 characters)
pastebin.py:376:1: W293 blank line contains whitespace
pastebin.py:378:80: E501 line too long (91 > 79 characters)
pastebin.py:383:1: W293 blank line contains whitespace
pastebin.py:385:30: E203 whitespace before ':'
pastebin.py:385:49: E202 whitespace before '}'
pastebin.py:387:70: W291 trailing whitespace
pastebin.py:399:76: W291 trailing whitespace
pastebin.py:403:1: W293 blank line contains whitespace
pastebin.py:410:5: E303 too many blank lines (2)
pastebin.py:412:1: W293 blank line contains whitespace
pastebin.py:431:1: W293 blank line contains whitespace
pastebin.py:433:1: W293 blank line contains whitespace
pastebin.py:434:1: W293 blank line contains whitespace
pastebin.py:436:80: E501 line too long (98 > 79 characters)
pastebin.py:437:1: W293 blank line contains whitespace
pastebin.py:438:1: W293 blank line contains whitespace
pastebin.py:440:80: E501 line too long (87 > 79 characters)
pastebin.py:442:1: W293 blank line contains whitespace
pastebin.py:444:30: E203 whitespace before ':'
pastebin.py:444:49: E202 whitespace before '}'
pastebin.py:453:76: W291 trailing whitespace
pastebin.py:457:1: W293 blank line contains whitespace
pastebin.py:464:5: E303 too many blank lines (2)
pastebin.py:464:70: E251 unexpected spaces around keyword / parameter equals
pastebin.py:464:72: E251 unexpected spaces around keyword / parameter equals
pastebin.py:466:1: W293 blank line contains whitespace
pastebin.py:467:1: W293 blank line contains whitespace
pastebin.py:478:80: E501 line too long (80 > 79 characters)
pastebin.py:487:1: W293 blank line contains whitespace
pastebin.py:489:1: W293 blank line contains whitespace
pastebin.py:490:1: W293 blank line contains whitespace
pastebin.py:492:80: E501 line too long (98 > 79 characters)
pastebin.py:493:1: W293 blank line contains whitespace
pastebin.py:495:80: E501 line too long (91 > 79 characters)
pastebin.py:496:1: W293 blank line contains whitespace
pastebin.py:501:80: E501 line too long (86 > 79 characters)
pastebin.py:505:30: E203 whitespace before ':'
pastebin.py:505:49: E202 whitespace before '}'
pastebin.py:514:1: W293 blank line contains whitespace
pastebin.py:530:76: W291 trailing whitespace
pastebin.py:534:1: W293 blank line contains whitespace
pastebin.py:541:5: E303 too many blank lines (2)
pastebin.py:543:1: W293 blank line contains whitespace
pastebin.py:544:1: W293 blank line contains whitespace
pastebin.py:548:80: E501 line too long (80 > 79 characters)
pastebin.py:553:1: W293 blank line contains whitespace
pastebin.py:554:1: W293 blank line contains whitespace
pastebin.py:556:80: E501 line too long (98 > 79 characters)
pastebin.py:557:1: W293 blank line contains whitespace
pastebin.py:559:80: E501 line too long (86 > 79 characters)
pastebin.py:560:1: W293 blank line contains whitespace
pastebin.py:562:80: E501 line too long (86 > 79 characters)
pastebin.py:565:80: E501 line too long (91 > 79 characters)
pastebin.py:566:1: W293 blank line contains whitespace
pastebin.py:569:30: E203 whitespace before ':'
pastebin.py:569:49: E202 whitespace before '}'
pastebin.py:580:80: E501 line too long (84 > 79 characters)
pastebin.py:583:80: E501 line too long (109 > 79 characters)
pastebin.py:590:5: E303 too many blank lines (2)
pastebin.py:591:13: E128 continuation line under-indented for visual indent
pastebin.py:591:25: E251 unexpected spaces around keyword / parameter equals
pastebin.py:591:27: E251 unexpected spaces around keyword / parameter equals
pastebin.py:591:44: E251 unexpected spaces around keyword / parameter equals
pastebin.py:591:46: E251 unexpected spaces around keyword / parameter equals
pastebin.py:591:65: E251 unexpected spaces around keyword / parameter equals
pastebin.py:591:67: E251 unexpected spaces around keyword / parameter equals
pastebin.py:592:13: E128 continuation line under-indented for visual indent
pastebin.py:592:26: E251 unexpected spaces around keyword / parameter equals
pastebin.py:592:28: E251 unexpected spaces around keyword / parameter equals
pastebin.py:592:52: E251 unexpected spaces around keyword / parameter equals
pastebin.py:592:54: E251 unexpected spaces around keyword / parameter equals
pastebin.py:595:1: W293 blank line contains whitespace
pastebin.py:596:1: W293 blank line contains whitespace
pastebin.py:603:80: E501 line too long (80 > 79 characters)
pastebin.py:603:81: W291 trailing whitespace
pastebin.py:609:1: W293 blank line contains whitespace
pastebin.py:612:80: E501 line too long (98 > 79 characters)
pastebin.py:613:1: W293 blank line contains whitespace
pastebin.py:615:80: E501 line too long (104 > 79 characters)
pastebin.py:616:1: W293 blank line contains whitespace
pastebin.py:618:80: E501 line too long (91 > 79 characters)
pastebin.py:632:80: E501 line too long (84 > 79 characters)
pastebin.py:641:80: E501 line too long (82 > 79 characters)
pastebin.py:650:9: E303 too many blank lines (2)
pastebin.py:650:30: E203 whitespace before ':'
pastebin.py:650:49: E202 whitespace before '}'
pastebin.py:692:76: W291 trailing whitespace
pastebin.py:697:42: W291 trailing whitespace
pastebin.py:702:5: E303 too many blank lines (2)
pastebin.py:703:13: E128 continuation line under-indented for visual indent
pastebin.py:703:23: E251 unexpected spaces around keyword / parameter equals
pastebin.py:703:25: E251 unexpected spaces around keyword / parameter equals
pastebin.py:703:45: E251 unexpected spaces around keyword / parameter equals
pastebin.py:703:47: E251 unexpected spaces around keyword / parameter equals
pastebin.py:704:13: E128 continuation line under-indented for visual indent
pastebin.py:704:30: E251 unexpected spaces around keyword / parameter equals
pastebin.py:704:32: E251 unexpected spaces around keyword / parameter equals
pastebin.py:704:51: E251 unexpected spaces around keyword / parameter equals
pastebin.py:704:53: E251 unexpected spaces around keyword / parameter equals
pastebin.py:709:1: W293 blank line contains whitespace
pastebin.py:710:1: W293 blank line contains whitespace
pastebin.py:722:1: W293 blank line contains whitespace
pastebin.py:724:80: E501 line too long (100 > 79 characters)
pastebin.py:725:1: W293 blank line contains whitespace
pastebin.py:729:1: W293 blank line contains whitespace
pastebin.py:731:80: E501 line too long (85 > 79 characters)
pastebin.py:740:80: E501 line too long (82 > 79 characters)
pastebin.py:754:17: E201 whitespace after '{'
pastebin.py:754:30: E203 whitespace before ':'
pastebin.py:754:48: E202 whitespace before '}'
pastebin.py:775:80: E501 line too long (85 > 79 characters)
pastebin.py:778:76: W291 trailing whitespace
pastebin.py:783:42: W291 trailing whitespace
pastebin.py:794:1: E303 too many blank lines (6)
pastebin.py:805:5: F821 undefined name 'main'
```

With the proposed fixes you get:

```
(venv:pruebas) (git:feature/pep8-fixes ✔) ➜ flake8 pastebin.py
pastebin.py:349:9: F841 local variable 'request' is assigned to but never used
pastebin.py:350:20: F821 undefined name 'request_string'
pastebin.py:483:80: E501 line too long (80 > 79 characters)
```

The `requests` errors will be gone with the my other pullreq https://github.com/Morrolan/PastebinAPI/pull/2
The error: `pastebin.py:483:80: E501 line too long (80 > 79 characters)` is for the line:

```
<paste_title>Pastebin.py - Python 3.2 Pastebin.com API</paste_title>
```

I didn't know which would be the better way to fix that so I left it unmodified.

I took the liberty to refactor some calls like:

``` python
request_string = urllib.urlopen(self._api_login_url, urllib.urlencode(argv))
```

turned into:

``` python
data = urllib.urlencode(argv)
request_string = urllib.urlopen(self._api_login_url, data)
```

to avoid lines > 80.

I hope you don't mind the cleanup, I think that a standardized code helps other people to contribute to projects.

I've separated the changes by 'category' or 'type of modification' to ease the review.

Cheers.
